### PR TITLE
[ Common ]  Header 컴포넌트 UI 구현

### DIFF
--- a/components/Common/Header/Header.tsx
+++ b/components/Common/Header/Header.tsx
@@ -9,33 +9,43 @@ const Header = () => {
 
   return (
     <StHeaderWrapper path={asPath}>
-      <p>헤더 컴포넌트입니다</p>
-      <IcLogo />
-      <IcProfile />
+      <StHeader>
+        <IcLogo />
+        <button type="button">
+          logout
+          <IcProfile />
+        </button>
+      </StHeader>
     </StHeaderWrapper>
   );
 };
 
 export default Header;
 
-// styled component는 앞에 St 접두사 붙이기!!!! (일반 컴포넌트와 구분을 위해서)
 const StHeaderWrapper = styled.header<{ path: string }>`
-  // css 순서 및 개행 컨벤션 지키기!!!
-  display: flex;
-  justify-content: space-between;
-
-  width: 100%;
-  height: 100px;
-
-  background-color: yellow;
-
-  & > p {
-    color: red;
-  }
+  height: 10rem;
+  padding: 5rem 10rem 0 5rem;
 
   ${({ path }) =>
     path === '/' &&
     css`
       display: none;
     `}
+`;
+
+const StHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+
+  width: 100%;
+
+  & > button {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.9rem;
+
+    color: ${({ theme }) => theme.colors.White};
+    ${({ theme }) => theme.fonts.Body0};
+  }
 `;

--- a/components/Common/Header/Header.tsx
+++ b/components/Common/Header/Header.tsx
@@ -1,20 +1,27 @@
 import { useRouter } from 'next/router';
 import { css, styled } from 'styled-components';
 
+import useModal from '@/hooks/useModal';
 import { IcLogo, IcProfile } from '@/public/assets/icons';
+
+import HeaderModal from './HeaderModal';
 
 const Header = () => {
   const router = useRouter();
   const { asPath } = router;
 
+  const { isShowing, toggle } = useModal();
+
   return (
     <StHeaderWrapper path={asPath}>
       <StHeader>
         <IcLogo />
-        <button type="button">
-          logout
+        <button type="button" onClick={toggle}>
           <IcProfile />
         </button>
+        <StHeaderModalWrapper>
+          <HeaderModal isShowing={isShowing} handleHide={toggle} />
+        </StHeaderModalWrapper>
       </StHeader>
     </StHeaderWrapper>
   );
@@ -34,6 +41,8 @@ const StHeaderWrapper = styled.header<{ path: string }>`
 `;
 
 const StHeader = styled.div`
+  position: relative;
+
   display: flex;
   justify-content: space-between;
 
@@ -48,4 +57,10 @@ const StHeader = styled.div`
     color: ${({ theme }) => theme.colors.White};
     ${({ theme }) => theme.fonts.Body0};
   }
+`;
+
+const StHeaderModalWrapper = styled.div`
+  position: absolute;
+  top: 5rem;
+  right: 0;
 `;

--- a/components/Common/Header/HeaderModal.tsx
+++ b/components/Common/Header/HeaderModal.tsx
@@ -8,12 +8,21 @@ interface HeaderModalProps {
 
 const HeaderModal = ({ isShowing, handleHide }: HeaderModalProps) => {
   const router = useRouter();
+
+  const handleProfile = () => {
+    console.log('프로필 설정 : 1차 데모 이후 구현');
+  };
+  const handleLogout = () => {
+    console.log('로그아웃 : 1차 데모 이후 구현');
+  };
+
   return (
     isShowing && (
       <StHeaderModalWrapper>
-        <button type="button" onClick={}>
+        <button type="button" onClick={handleProfile}>
           프로필 설정
         </button>
+        <hr />
         <button
           type="button"
           onClick={() => {
@@ -22,7 +31,8 @@ const HeaderModal = ({ isShowing, handleHide }: HeaderModalProps) => {
         >
           마이페이지
         </button>
-        <button type="button" onClick={}>
+        <hr />
+        <button type="button" onClick={handleLogout}>
           logout
         </button>
       </StHeaderModalWrapper>
@@ -33,8 +43,29 @@ const HeaderModal = ({ isShowing, handleHide }: HeaderModalProps) => {
 export default HeaderModal;
 
 const StHeaderModalWrapper = styled.div`
-  width: 7rem;
-  height: 5.7rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 0.3rem;
+
+  width: 10rem;
+  height: fit-content;
+  padding: 0.6rem;
+  box-sizing: border-box;
+
   border-radius: 0.5rem;
   background: ${({ theme }) => theme.colors.Purple1};
+
+  & > button {
+    color: ${({ theme }) => theme.colors.White};
+    ${({ theme }) => theme.fonts.Body2};
+  }
+  & > hr {
+    border: none;
+    border-top: 0.06rem solid ${({ theme }) => theme.colors.White};
+    width: 100%;
+  }
+  & > button:hover {
+    color: ${({ theme }) => theme.colors.Blue};
+  }
 `;

--- a/components/Common/Header/HeaderModal.tsx
+++ b/components/Common/Header/HeaderModal.tsx
@@ -1,0 +1,40 @@
+import { useRouter } from 'next/router';
+import { styled } from 'styled-components';
+
+interface HeaderModalProps {
+  isShowing: boolean;
+  handleHide: React.MouseEventHandler;
+}
+
+const HeaderModal = ({ isShowing, handleHide }: HeaderModalProps) => {
+  const router = useRouter();
+  return (
+    isShowing && (
+      <StHeaderModalWrapper>
+        <button type="button" onClick={}>
+          프로필 설정
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            router.push('/mypage');
+          }}
+        >
+          마이페이지
+        </button>
+        <button type="button" onClick={}>
+          logout
+        </button>
+      </StHeaderModalWrapper>
+    )
+  );
+};
+
+export default HeaderModal;
+
+const StHeaderModalWrapper = styled.div`
+  width: 7rem;
+  height: 5.7rem;
+  border-radius: 0.5rem;
+  background: ${({ theme }) => theme.colors.Purple1};
+`;

--- a/components/Common/Header/index.tsx
+++ b/components/Common/Header/index.tsx
@@ -1,1 +1,2 @@
 export { default as Header } from './Header';
+export { default as HeaderModal } from './HeaderModal';

--- a/hooks/useModal.ts
+++ b/hooks/useModal.ts
@@ -2,7 +2,7 @@
 import { useState } from 'react';
 
 const useModal = () => {
-  const [isShowing, setIsShowing] = useState(false);
+  const [isShowing, setIsShowing] = useState(true);
 
   const toggle = () => setIsShowing((prev) => !prev);
 

--- a/public/assets/icons/ic_ballon.svg
+++ b/public/assets/icons/ic_ballon.svg
@@ -1,0 +1,17 @@
+<svg width="269" height="114" viewBox="0 0 269 114" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_536_3176)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M264 25.0362C264 13.9905 255.046 5.03613 244 5.03613H25C13.9543 5.03613 5 13.9904 5 25.0361V54.8321C5 65.8778 13.9543 74.8321 25 74.8321H204.855C207.535 82.5989 215.183 88.204 224.199 88.204C233.215 88.204 240.863 82.5989 243.544 74.8321H244C255.046 74.8321 264 65.8778 264 54.8321V25.0362ZM203.388 108.228C197.772 108.228 193.221 103.873 193.221 98.5008C193.221 93.1285 197.772 88.7734 203.388 88.7734C209.003 88.7734 213.555 93.1285 213.555 98.5008C213.555 103.873 209.003 108.228 203.388 108.228Z" fill="white"/>
+</g>
+<defs>
+<filter id="filter0_d_536_3176" x="0" y="0.0361328" width="269" height="113.192" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="2.5"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_536_3176"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_536_3176" result="shape"/>
+</filter>
+</defs>
+</svg>


### PR DESCRIPTION
<!--  제목 : [ 페이지명 ] 내용 (ex. [ Login ] Github 소셜로그인 구현) -->

## 🔥 Related Issues

resolved #1 

## 💜 작업 내용

- [x] Header 컴포넌트 UI 구현
- [x] Header 랜딩페이지에서 안보이게 조건부 스타일링

## ✅ PR Point

- padding 속성을 통해서 화면 전체 width가 변해도 반응형으로 헤더 너비가 조절되게 구현했습니다.
- 라우팅이 '/' (랜딩페이지) 인 경우에는 헤더 안보이게 처리했습니다.
  ``` jsx
  const StHeaderWrapper = styled.header<{ path: string }>`
    height: 10rem;
    padding: 5rem 10rem 0 5rem;
  
    ${({ path }) =>
      path === '/' &&
      css`
        display: none;
      `}
  `;
  ```
@hyoseung2000 
- 헤더 컴포넌트 작업 시 `feature-common` 브랜치 가서 pull 받고 ->  `commn/이슈번호` 브랜치 생성해서 작업하시면 됩니다!
- 로그인/로그아웃 구현 시 `button`에 onClick 함수 넣어서 구현해주시면 됩니다!

## 👀 스크린샷 / GIF / 링크
<img width="1170" alt="image" src="https://github.com/Team-Learniverse/Learniverse-FrontEnd/assets/73213437/ea6fedac-615f-4e3f-bd0a-b9f0a9cb50a1">

